### PR TITLE
[PS-15] Adding RabbitMQ to Emerald + Devtools

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -34,7 +34,8 @@
         }
     },
     "rabbitmq":{
-        "url" : "amqp://guest:guest@1277.0.0.1:5672"
+        "url" : "amqp://guest:guest@1277.0.0.1:5672",
+        "queue": "Miner::Metrics"
     },
     "monero":{
         "daemon":{

--- a/config/default.json
+++ b/config/default.json
@@ -33,6 +33,9 @@
             "maxJump": 100
         }
     },
+    "rabbitmq":{
+        "url" : "amqp://guest:guest@1277.0.0.1:5672"
+    },
     "monero":{
         "daemon":{
             "host": "0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "amqplib": "^0.5.5",
     "app-module-path": "^2.2.0",
     "axios": "^0.19.0",
     "body-parser": "^1.19.0",

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ const config = require('src/util/config.js');
 const logger = require('src/util/logger.js');
 
 const cache = require('src/util/cache.js');
+const mq = require('src/util/mq.js');
 // Eventually refactor when migrating to K8 so that every pod is a worker with a master pod
 //  instead of using cluster module from javascript
 let server;
@@ -16,7 +17,11 @@ const main = async () => {
   
   logger.core.info('Initializing cache DB');
   cache.init(config.get('cache'));
-  logger.core.info('Cache Initialized');
+  logger.core.info('Cache initialized');
+
+  logger.core.info('Initializing messaging queue RabbitMQ');
+  mq.init(config.get('rabbitmq:url'));
+  logger.core.info('Messaging queue initialized');
 
   const pool = require('src/pool.js');
   const port = config.get('pool:port');

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,6 @@ const main = async () => {
 
 const gracefulShutdown = () => {
   server.close(async () => {
-    // await some DB shut down
     console.log(`${config.get('service')} is gracefully shutting down on port ${port}`);
     process.exit(0);
   });

--- a/src/services/metrics.service.js
+++ b/src/services/metrics.service.js
@@ -7,8 +7,7 @@ const MetricsServices = {
             accountId: minerId,
             ...metrics
         }
-        const msgString = JSON.stringify(msg);
-        return mq.send(msgString)
+        return mq.send(msg)
         .then((res) => {
             if (-1 == res) {
                 // Soft handle failure

--- a/src/services/metrics.service.js
+++ b/src/services/metrics.service.js
@@ -1,0 +1,21 @@
+const mq = require('src/util/mq.js');
+
+const MetricsServices = {
+
+    broadcast: (minerId, metrics) => {
+        const msg = {
+            accountId: minerId,
+            ...metrics
+        }
+        const msgString = JSON.stringify(msg);
+        return mq.send(msgString)
+        .then((res) => {
+            if (-1 == res) {
+                // Soft handle failure
+                //  Should probably shove this in the cache for now... and try again later with CRON job
+            }
+        })
+    }
+}
+
+module.exports = MetricsServices;

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -12,7 +12,8 @@ const logger = bunyan.createLogger({
 
 module.exports = {
   core: logger.child({component: 'core'}),
-  db: logger.child({component: 'db'}),
+  db: logger.child({component: 'database'}),
+  mq: logger.child({component: 'messaging_queue'}),
   cache: logger.child({component: 'cache'}),
   monero: logger.child({component: 'monero'}),
   block: logger.child({component: 'block_service'}),

--- a/src/util/mq.js
+++ b/src/util/mq.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const amq = require('amqplib');
+
+const logger = require('src/util/logger.js').mq;
+
+const queue = 'MinerMetrics';
+let channel;
+
+const MQ = {
+
+    init: (url) => {
+        return amq.connect(url)
+        .then(conn => {
+            return conn.createChannel();
+        })
+        .then(ch => {
+            channel = ch;
+            return channel.assertQueue(queue);
+        })
+        .catch(logger.error);
+    },
+
+    send: (msg) => {
+        return channel.assertQueue(queue)
+        .then(ok => {
+            logger.info(`Sending: ${msg}\n on queue ${queue}`);
+            return channel.sendToQueue(queue, msg);
+        })
+        .then(() => {
+            return 0;
+        })
+        .catch(err => {
+            logger.error(err);
+            logger.error(`Error occured while sending: \n ${msg}`);
+            return -1;
+        });
+    },
+
+    registerConsumer: (cb) => {
+        return channel.assertQueue(queue)
+        .then(ok => {
+            return channel.consume(queue, (msg) => {
+                if (null !== msg){
+                    channel.ack(msg);
+                    logger.info(`Consuming message: ${msg.content.toString()}\n from queue ${queue}`);
+                    cb(msg.content);
+                }
+            });
+        })
+        .cathc(err => {
+            logger.error(err);
+        });
+    }
+
+}
+
+module.exports = MQ;

--- a/test/config/testing.json
+++ b/test/config/testing.json
@@ -1,0 +1,5 @@
+{
+    "rabbitmq": {
+        "queue": "Miner::Metrics::Test"
+    }
+}

--- a/test/services/metrics.service.test.js
+++ b/test/services/metrics.service.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const testing = require('../test.init.js');
+
+const MetricsService = require('src/services/metrics.service.js');
+const config = require('src/util/config.js');
+require('chai')
+    .use(require('chai-as-promised'))
+    .use(require('chai-string'))
+    .should();
+
+describe('Metrics Service Unit Tests', () => {
+
+    before('Await MQ initialization', () => {
+        return testing.mqReady;
+    })
+    it('Should successfully send a message', () => {
+        return MetricsService.broadcast('1', {
+            testing: 100
+        })
+        .then(() =>{
+            return testing.mq.channel.consume(config.get('rabbitmq:queue'), (msg) => {
+                return new Promise((resolve, reject) => {
+                    testing.mq.channel.ack(msg);
+                    let data = JSON.parse(msg.content.toString());
+                    data.should.not.be.null;
+                    data.testing.should.equal(100);
+                    data.accountId.should.equal('1');
+                    resolve();
+                }) 
+            });
+        })
+        .catch(err => {
+            console.log(err);
+        })
+    })
+})

--- a/test/test.init.js
+++ b/test/test.init.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const path = require('path');
+
+const rootPath = path.resolve(`${__dirname}/../`);
+require('app-module-path').addPath(rootPath);
+
+const logger = require('src/util/logger.js');
+// initialize config
+const configPath = path.resolve(`${rootPath}/config`);
+const config = require('nconf')
+    .argv()
+    .env({ lowerCase: true, separator: '__' })
+    .file('testing', { file: `${rootPath}/test/config/testing.json` })
+    .file('environment', { file: `${configPath}/${process.env.NODE_ENV}.json` })
+    .file('defaults', { file: `${configPath}/default.json` });
+
+// initialize Cache
+const cache = require('src/util/cache.js');
+cache.init(config.get('cache'));
+
+// initialize Testing MQ
+const mq = require('src/util/mq.js');
+const mqReady = mq.init(config.get('rabbitmq:url'));
+
+// other libs
+const should = require('chai')
+    .use(require('chai-as-promised'))
+    .use(require('chai-string'))
+    .should();
+
+process.on('unhandledRejection', (reason, promise) => {
+    /* eslint-disable no-console */
+    console.error('Unhandled promise rejection:'); 
+    console.error(reason);
+    process.exit(57);
+    // If you noticed an exit code of 57, and grepped for it, now you know why.
+    /* eslint-enable no-console */
+});
+
+
+module.exports = {
+    mq,
+    mqReady,
+    cache,
+    config,
+    should,
+};


### PR DESCRIPTION
Ticket | Title
---|---
[PS-15](https://trello.com/c/7J9uKz93/50-ps-15-adding-rabbitmq-to-emerald-devtools) | Adding RabbitMQ to Emerald + Devtools

## Context
Unblocking another ticket: [PS-12](https://trello.com/c/0IyxbeZZ/47-ps-12-implement-mq-for-emerald-sapphire) 
Allowing to use the RabbitMQ messaging queue to send miner metrics from Emerald &rarr; Sapphire

## Description

* Added RabbitMQ and AMQLib into Emerald, under `src/util/mq.js`
* Added abstraction service layer called `MetricsService` that has `broadcast(minerId, metrics)` function
---
- [x] Ready for merge
- [x] Added unit tests
- [x] Safe to rollback
