### PR TITLE
Change to nvm for node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,38 @@
-FROM ubuntu:18.04 as builder
+  # WORKDIR /usr/src/build
+  # RUN chmod 777 /usr/src/build
+FROM ubuntu:18.04
 
-  RUN apt update && apt install -y nodejs npm 
+  # Building final image
+  WORKDIR /usr/src/app
+  EXPOSE 8088
+  EXPOSE 12345
+  ENV NODE_ENV "prod"
 
-  RUN apt-get install -y libboost-all-dev
-  RUN apt-get update && apt-get install -y git
-  WORKDIR /usr/src/build
-  RUN chmod 777 /usr/src/build
+  RUN apt-get update \
+      && apt-get -y install curl gnupg sudo libboost-all-dev git
+  
+  # Setup for nvm
+  RUN mkdir /usr/local/nvm
+  ENV NVM_DIR /usr/local/nvm 
+  ENV NODE_VERSION v10.17.0
+  RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash 
+  
+  RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"
+  
+  ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
+  ENV PATH      $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
+ 
   # Install && build app dependencies
   COPY . . 
   RUN rm -rf node_modules
   RUN npm install
 
-FROM ubuntu:18.04 as app
-  # Building final image
-  WORKDIR /usr/src/app
-  EXPOSE 8088
-  EXPOSE 12345
-  RUN apt update && apt install -y nodejs libboost-all-dev
+  CMD [ "node", "src/main.js" ]
 
 #   RUN chown -R node:node /usr/src/app
 #   USER node
-  ENV NODE_ENV "prod"
 #   COPY --from=builder /usr/local/lib /usr/local/lib
 #   COPY --from=builder /usr/lib /usr/lib
-#   COPY --from=builder /usr/local/lib /usr/local/lib
-  COPY --from=builder /usr/src/build/ /usr/src/app/
-  CMD [ "node", "src/main.js" ]
+#   COPY --from=builder /usr/src/build/ /usr/src/app/
+ 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,27 +1,38 @@
+  # WORKDIR /usr/src/build
+  # RUN chmod 777 /usr/src/build
 FROM ubuntu:18.04
+  WORKDIR /usr/src/app
+  EXPOSE 8088
+  EXPOSE 12345
+  EXPOSE 9878
 
-RUN apt-get update && apt-get install -y curl
-# Setup for nvm
-RUN mkdir /usr/local/nvm
-ENV NVM_DIR /usr/local/nvm 
-ENV NODE_VERSION v10.17.0
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash 
+  RUN apt-get update \
+      && apt-get -y install curl gnupg sudo libboost-all-dev git
+  
+  # Setup for nvm
+  RUN mkdir /usr/local/nvm
+  ENV NVM_DIR /usr/local/nvm 
+  ENV NODE_VERSION v10.17.0
+  RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash 
+  
+  RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"
+  
+  ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
+  ENV PATH      $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
-RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"
+ 
+  # Install && build app dependencies
+  COPY . . 
+  RUN rm -rf node_modules
+  RUN npm install
 
-ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
+  RUN chmod 777 /usr/src/app
 
-RUN apt-get install -y libboost-all-dev
-RUN apt-get update && apt-get install -y git
+  CMD [ "node", "/usr/src/app/src/main.js" ]
 
-WORKDIR /usr/src/app
-
-COPY . .
-RUN chmod 777 /usr/src/app
-
-EXPOSE 8088
-EXPOSE 12345
-EXPOSE 9878
-
-CMD node /usr/src/app/src/main.js
+#   RUN chown -R node:node /usr/src/app
+#   USER node
+#   COPY --from=builder /usr/local/lib /usr/local/lib
+#   COPY --from=builder /usr/lib /usr/lib
+#   COPY --from=builder /usr/src/build/ /usr/src/app/
+ 


### PR DESCRIPTION
Changes to `Dockerfile` to use `nvm` instead, should change later to split into builder and app images